### PR TITLE
Added flush function

### DIFF
--- a/PS2Keyboard.cpp
+++ b/PS2Keyboard.cpp
@@ -353,6 +353,11 @@ bool PS2Keyboard::available() {
 	return false;
 }
 
+void PS2Keyboard::flush() {
+    CharBuffer = 0;
+    UTF8next = 0;
+}
+
 int PS2Keyboard::read() {
 	uint8_t result;
 

--- a/PS2Keyboard.h
+++ b/PS2Keyboard.h
@@ -202,6 +202,11 @@ class PS2Keyboard {
     static bool available();
     
     /**
+     * Sets available() to false without a call to read()
+     */
+    static void flush();
+    
+    /**
      * Returns the char last read from the keyboard.
      * If there is no char available, -1 is returned.
      */


### PR DESCRIPTION
It's more readable to call `static void flush()` instead of `static int read()` **if the data doesn't matter** and it's just necessary to set `static bool available()` back to `false`.