### PR TITLE
Support for NodeMCU 0.9 (ESP-12 Module) / NodeMCU 1.0 (ESP-12E Module) modules.

### DIFF
--- a/PS2Keyboard.cpp
+++ b/PS2Keyboard.cpp
@@ -149,7 +149,7 @@ const PROGMEM PS2Keymap_t PS2Keymap_US = {
 	'0', '.', '2', '5', '6', '8', PS2_ESC, 0 /*NumLock*/,
 	PS2_F11, '+', '3', '-', '*', '9', PS2_SCROLL, 0,
 	0, 0, 0, PS2_F7 },
-	{0}
+	0
 };
 
 
@@ -190,7 +190,7 @@ const PROGMEM PS2Keymap_t PS2Keymap_German = {
 	'0', '.', '2', '5', '6', '8', PS2_ESC, 0 /*NumLock*/,
 	PS2_F11, '+', '3', '-', '*', '9', PS2_SCROLL, 0,
 	0, 0, 0, PS2_F7 },
-	{1},
+	1,
   // with altgr
 	{0, PS2_F9, 0, PS2_F5, PS2_F3, PS2_F1, PS2_F2, PS2_F12,
 	0, PS2_F10, PS2_F8, PS2_F6, PS2_F4, PS2_TAB, 0, 0,
@@ -249,7 +249,7 @@ const PROGMEM PS2Keymap_t PS2Keymap_French = {
 	'0', '.', '2', '5', '6', '8', PS2_ESC, 0 /*NumLock*/,
 	PS2_F11, '+', '3', '-', '*', '9', PS2_SCROLL, 0,
 	0, 0, 0, PS2_F7 },
-	{1},
+	1,
   // with altgr
 	{0, PS2_F9, 0, PS2_F5, PS2_F3, PS2_F1, PS2_F2, PS2_F12,
 	0, PS2_F10, PS2_F8, PS2_F6, PS2_F4, PS2_TAB, 0, 0,
@@ -307,7 +307,7 @@ const PROGMEM PS2Keymap_t PS2Keymap_Spanish = {
 		 '0', '.', '2', '5', '6', '8', PS2_ESC, 0 /*NumLock*/,
 		 PS2_F11, '+', '3', '-', '*', '9', PS2_SCROLL, 0,
 		 0, 0, 0, PS2_F7 },
-         {1},
+         1,
 		// with altgr
 		{0, PS2_F9, 0, PS2_F5, PS2_F3, PS2_F1, PS2_F2, PS2_F12,
 		 0, PS2_F10, PS2_F8, PS2_F6, PS2_F4, PS2_TAB, '\\', 0,

--- a/PS2Keyboard.cpp
+++ b/PS2Keyboard.cpp
@@ -149,7 +149,7 @@ const PROGMEM PS2Keymap_t PS2Keymap_US = {
 	'0', '.', '2', '5', '6', '8', PS2_ESC, 0 /*NumLock*/,
 	PS2_F11, '+', '3', '-', '*', '9', PS2_SCROLL, 0,
 	0, 0, 0, PS2_F7 },
-	0
+	{0}
 };
 
 
@@ -190,7 +190,7 @@ const PROGMEM PS2Keymap_t PS2Keymap_German = {
 	'0', '.', '2', '5', '6', '8', PS2_ESC, 0 /*NumLock*/,
 	PS2_F11, '+', '3', '-', '*', '9', PS2_SCROLL, 0,
 	0, 0, 0, PS2_F7 },
-	1,
+	{1},
   // with altgr
 	{0, PS2_F9, 0, PS2_F5, PS2_F3, PS2_F1, PS2_F2, PS2_F12,
 	0, PS2_F10, PS2_F8, PS2_F6, PS2_F4, PS2_TAB, 0, 0,
@@ -249,7 +249,7 @@ const PROGMEM PS2Keymap_t PS2Keymap_French = {
 	'0', '.', '2', '5', '6', '8', PS2_ESC, 0 /*NumLock*/,
 	PS2_F11, '+', '3', '-', '*', '9', PS2_SCROLL, 0,
 	0, 0, 0, PS2_F7 },
-	1,
+	{1},
   // with altgr
 	{0, PS2_F9, 0, PS2_F5, PS2_F3, PS2_F1, PS2_F2, PS2_F12,
 	0, PS2_F10, PS2_F8, PS2_F6, PS2_F4, PS2_TAB, 0, 0,
@@ -307,7 +307,7 @@ const PROGMEM PS2Keymap_t PS2Keymap_Spanish = {
 		 '0', '.', '2', '5', '6', '8', PS2_ESC, 0 /*NumLock*/,
 		 PS2_F11, '+', '3', '-', '*', '9', PS2_SCROLL, 0,
 		 0, 0, 0, PS2_F7 },
-		1,
+         {1},
 		// with altgr
 		{0, PS2_F9, 0, PS2_F5, PS2_F3, PS2_F1, PS2_F2, PS2_F12,
 		 0, PS2_F10, PS2_F8, PS2_F6, PS2_F4, PS2_TAB, '\\', 0,

--- a/PS2Keyboard.h
+++ b/PS2Keyboard.h
@@ -168,10 +168,10 @@
 typedef struct {
 	uint8_t noshift[PS2_KEYMAP_SIZE];
 	uint8_t shift[PS2_KEYMAP_SIZE];
-	uint8_t uses_altgr[1];
+	unsigned int uses_altgr;
     /*
      * "uint8_t uses_altgr;" makes the ESP8266 - NodeMCU modules crash.
-     * So, I replaced it with a array and... It works!
+     * So, I replaced it with an int and... It works!
      * I think it's because of the 32-bit architecture of the ESP8266
      * and the use of the flash memory to store the keymaps.
      * Maybe I'm wrong, it remains a hypothesis.

--- a/PS2Keyboard.h
+++ b/PS2Keyboard.h
@@ -168,7 +168,14 @@
 typedef struct {
 	uint8_t noshift[PS2_KEYMAP_SIZE];
 	uint8_t shift[PS2_KEYMAP_SIZE];
-	uint8_t uses_altgr;
+	uint8_t uses_altgr[1];
+    /*
+     * "uint8_t uses_altgr;" makes the ESP8266 - NodeMCU modules crash.
+     * So, I replaced it with a array and... It works!
+     * I think it's because of the 32-bit architecture of the ESP8266
+     * and the use of the flash memory to store the keymaps.
+     * Maybe I'm wrong, it remains a hypothesis.
+     */
 	uint8_t altgr[PS2_KEYMAP_SIZE];
 } PS2Keymap_t;
 

--- a/utility/int_pins.h
+++ b/utility/int_pins.h
@@ -55,6 +55,10 @@
 #elif defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
   #define CORE_INT0_PIN  2
 
+//ESP8266 - NodeMCU 0.9 (ESP-12 Module) / NodeMCU 1.0 (ESP-12E Module)
+#elif defined(ARDUINO_ESP8266_NODEMCU)
+  #define CORE_INT_EVERY_PIN
+  
 // Arduino Uno, Duemilanove, LilyPad, Mini, Fio, etc...
 #else
   #define CORE_INT0_PIN  2


### PR DESCRIPTION
Hello !

PS2Keyboard now supports NodeMCU 0.9 (ESP-12 Module) / NodeMCU 1.0 (ESP-12E Module) modules!

By the way, I fixed a cash with these modules (see changes).

P.S. :  `PS2_EURO_SIGN` doesn't work.

Sorry for my bad English, I'm French.

Have a good day!
Sincerely.




