### PR TITLE
Add quick-start info to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,81 @@
-#PS/2 Keyboard Library#
+## PS/2 Keyboard Library
 
 PS2Keyboard allows you to use a keyboard for user input. 
 
-http://www.pjrc.com/teensy/td_libs_PS2Keyboard.html
+Full documentation: http://www.pjrc.com/teensy/td_libs_PS2Keyboard.html
 
-![](http://www.pjrc.com/teensy/td_libs_PS2Keyboard.jpg)
+![PS/2 keyboard port plugged into Arduino board](http://www.pjrc.com/teensy/td_libs_PS2Keyboard.jpg)
+
+# Basic Usage
+
+```c++
+PS2Keyboard keyboard;
+```
+Create the keyboard object. Even though you could create multiple objects, only a single PS2 keyboard is supported by this library.
+
+```c++
+keyboard.begin(DataPin, IRQpin)
+```
+Begin receiving keystrokes. `DataPin` and `IRQpin` are the pin numbers to which you connected the PS/2 keyboard's Data and Clock signals.
+
+```c++
+keyboard.available()
+```
+Returns `true` if at least one keystroke has been received.
+
+```c++
+keyboard.read()
+```
+Read the next keystroke. `-1` is returned if no keystrokes have been received. Keystrokes are returned as ASCII characters; special keys are mapped to their control characters.
+
+# Sample Program
+```c++
+#include <PS2Keyboard.h>
+
+const int DataPin = 8;
+const int IRQpin =  5;
+
+PS2Keyboard keyboard;
+
+void setup() {
+  delay(1000);
+  keyboard.begin(DataPin, IRQpin);
+  Serial.begin(9600);
+  Serial.println("Keyboard Test:");
+}
+
+void loop() {
+  if (keyboard.available()) {
+    
+    // read the next key
+    char c = keyboard.read();
+    
+    // check for some of the special keys
+    if (c == PS2_ENTER) {
+      Serial.println();
+    } else if (c == PS2_TAB) {
+      Serial.print("[Tab]");
+    } else if (c == PS2_ESC) {
+      Serial.print("[ESC]");
+    } else if (c == PS2_PAGEDOWN) {
+      Serial.print("[PgDn]");
+    } else if (c == PS2_PAGEUP) {
+      Serial.print("[PgUp]");
+    } else if (c == PS2_LEFTARROW) {
+      Serial.print("[Left]");
+    } else if (c == PS2_RIGHTARROW) {
+      Serial.print("[Right]");
+    } else if (c == PS2_UPARROW) {
+      Serial.print("[Up]");
+    } else if (c == PS2_DOWNARROW) {
+      Serial.print("[Down]");
+    } else if (c == PS2_DELETE) {
+      Serial.print("[Del]");
+    } else {
+      
+      // otherwise, just print all normal characters
+      Serial.print(c);
+    }
+  }
+}
+```


### PR DESCRIPTION
Copied some of the usage/initialization info from the website, in order to keep it with the repo README for those who use the web view here on GitHub.

The library is super useful; I am using it for a few keyboard converters for old computers right now.